### PR TITLE
Fix typo in error message

### DIFF
--- a/src/hatch_fancy_pypi_readme/_fragments.py
+++ b/src/hatch_fancy_pypi_readme/_fragments.py
@@ -132,7 +132,7 @@ class FileFragment:
                 contents, _ = contents.split(end_before, 1)
             except ValueError:
                 errs.append(
-                    f"file fragment: 'end_before' {end_before!r} not found."
+                    f"file fragment: 'end-before' {end_before!r} not found."
                 )
 
         if pattern:

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -139,7 +139,7 @@ This is the *interesting* body!"""
 
         assert [
             "file fragment: 'start-after' 'nope' not found.",
-            "file fragment: 'end_before' 'also nope' not found.",
+            "file fragment: 'end-before' 'also nope' not found.",
         ] == ei.value.errors
 
     def test_invalid_pattern(self, txt_path):


### PR DESCRIPTION
This PR fixes a minor typo in the error message raised when the end-before marker isn't found.
