### PR TITLE
Add support `setuptools`?

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dependencies = [
 [project.entry-points.hatch]
 fancy-pypi-readme = "hatch_fancy_pypi_readme.hooks"
 
+[project.entry-points."setuptools.finalize_distribution_options"]
+fancy-pypi-readme = "hatch_fancy_pypi_readme._setuptools:update_metadata"
+
 [project.scripts]
 hatch-fancy-pypi-readme = "hatch_fancy_pypi_readme.__main__:main"
 

--- a/src/hatch_fancy_pypi_readme/_config.py
+++ b/src/hatch_fancy_pypi_readme/_config.py
@@ -22,20 +22,22 @@ class Config:
 _BASE = "tool.hatch.metadata.hooks.fancy-pypi-readme."
 
 
-def load_and_validate_config(config: dict[str, Any]) -> Config:
+def load_and_validate_config(
+    config: dict[str, Any], base: str = _BASE
+) -> Config:
     errs = []
 
     ct = config.get("content-type")
     if ct is None:
-        errs.append(f"{_BASE}content-type is missing.")
+        errs.append(f"{base}content-type is missing.")
     elif ct not in ("text/markdown", "text/x-rst"):
         errs.append(
-            f"{_BASE}content-type: '{ct}' is not one of "
+            f"{base}content-type: '{ct}' is not one of "
             "['text/markdown', 'text/x-rst']"
         )
 
     try:
-        fragments = _load_fragments(config.get("fragments"))
+        fragments = _load_fragments(config.get("fragments"), base)
     except ConfigurationError as e:
         errs.extend(e.errors)
 
@@ -43,7 +45,7 @@ def load_and_validate_config(config: dict[str, Any]) -> Config:
         subs_cfg = config.get("substitutions", [])
         if not isinstance(subs_cfg, list):
             raise ConfigurationError(
-                [f"{_BASE}substitutions must be an array."]
+                [f"{base}substitutions must be an array."]
             )
 
         substitutions = [
@@ -62,14 +64,16 @@ def load_and_validate_config(config: dict[str, Any]) -> Config:
     )
 
 
-def _load_fragments(config: list[dict[str, str]] | None) -> list[Fragment]:
+def _load_fragments(
+    config: list[dict[str, str]] | None, base: str
+) -> list[Fragment]:
     """
     Load fragments from *config*.
     """
     if config is None:
-        raise ConfigurationError([f"{_BASE}fragments is missing."])
+        raise ConfigurationError([f"{base}fragments is missing."])
     if not config:
-        raise ConfigurationError([f"{_BASE}fragments must not be empty."])
+        raise ConfigurationError([f"{base}fragments must not be empty."])
 
     frags = []
     errs = []

--- a/src/hatch_fancy_pypi_readme/_setuptools.py
+++ b/src/hatch_fancy_pypi_readme/_setuptools.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+from ._builder import build_text
+from ._config import Config, load_and_validate_config
+
+if sys.version_info < (3, 11):
+    import tomli as tomllib
+else:
+    import tomllib
+
+if TYPE_CHECKING:
+    from setuptools import Distribution
+
+
+_NAME = "fancy-pypi-readme"
+
+
+def get_config() -> Config | None:
+    with open("pyproject.toml", "rb") as f:
+        tools = tomllib.load(f).get("tool") or {}
+
+    return (
+        load_and_validate_config(tools[_NAME], f"tool.{_NAME}.")
+        if _NAME in tools
+        else None
+    )
+
+
+def update_metadata(dist: Distribution) -> None:
+    """Update the distribution's core metadata description"""
+    config = get_config()
+    if config:
+        dist.metadata.long_description = build_text(
+            config.fragments,
+            config.substitutions,
+            version=dist.metadata.get_version(),
+        )
+        dist.metadata.long_description_content_type = config.content_type
+
+
+# Delay hook so that plugins like setuptools-scm can run first:
+update_metadata.order = 100  # type: ignore[attr-defined]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,7 @@
 
 import subprocess
 import sys
+from functools import reduce
 
 import pytest
 
@@ -23,3 +24,9 @@ def run(*args, check=True):
 
 def append(file, text):
     file.write_text(file.read_text() + text)
+
+
+def replace(file, subs):
+    file.write_text(
+        reduce(lambda acc, x: acc.replace(*x), subs.items(), file.read_text())
+    )


### PR DESCRIPTION
Hello, I was recently wondering how much different/complex would it be to support the same functionality of `hatch-fancy-pypi-readme` in setuptools.

After looking at the `hooks.py` file, I noticed that the hook implementation for setuptools would not be too much different than the one for hatch...

This PR contains a preliminary proof of concept.
Please let me know if you have interest on this and I can follow up with any required changes (e.g. docs).

Otherwise please also feel free to close the PR.