### PR TITLE
`$HFPR_PACKAGE_NAME` is now replaced with package name in readme substitutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The **third number** is for emergencies when we need to start branches for older
 
 ## [Unreleased](https://github.com/hynek/hatch-fancy-pypi-readme/compare/24.1.0...HEAD)
 
+### Added
+
+- `$HFPR_PACKAGE_NAME` is now replaced by the package name in the PyPI readme.
+  The version is not available in CLI mode, therefore it's replaced by the dummy value of `your-package`.
+
 ### Removed
 
 - Support for Python 3.7.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The **third number** is for emergencies when we need to start branches for older
 
 - `$HFPR_PACKAGE_NAME` is now replaced by the package name in the PyPI readme.
   The version is not available in CLI mode, therefore it's replaced by the dummy value of `your-package`.
+  [#64](https://github.com/hynek/hatch-fancy-pypi-readme/pull/64)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -243,10 +243,10 @@ Again, please check out our [example configuration][example-config] for a comple
 
 ### Referencing Packaging Metadata
 
-If the final readme contains the string `$HFPR_VERSION`, it is replaced by the current package version.
+If the final readme contains the strings `$HFPR_PACKAGE_NAME` or `$HFPR_VERSION`, they will be replaced by the current package name or version.
 
 When running *hatch-fancy-pypi-readme* in CLI mode (as described in the next section), packaging metadata is not available.
-In that case `$HFPR_VERSION` is hardcoded to `42.0` so you can still test your readme.
+In that case `$HFPR_PACKAGE_NAME` is hardcoded to `your-package`, and `$HFPR_VERSION` to `42.0`, so you can still test your readme.
 
 
 ## CLI Interface

--- a/src/hatch_fancy_pypi_readme/_builder.py
+++ b/src/hatch_fancy_pypi_readme/_builder.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 def build_text(
     fragments: list[Fragment],
     substitutions: list[Substituter],
+    package_name: str = "",
     version: str = "",
 ) -> str:
     """
@@ -26,4 +27,6 @@ def build_text(
     for sub in substitutions:
         text = sub.substitute(text)
 
-    return text.replace("$HFPR_VERSION", version)
+    return text.replace("$HFPR_PACKAGE_NAME", package_name).replace(
+        "$HFPR_VERSION", version
+    )

--- a/src/hatch_fancy_pypi_readme/_cli.py
+++ b/src/hatch_fancy_pypi_readme/_cli.py
@@ -65,7 +65,12 @@ def cli_run(
             + "\n".join(f"- {msg}" for msg in e.errors),
         )
 
-    print(build_text(config.fragments, config.substitutions, "42.0"), file=out)
+    print(
+        build_text(
+            config.fragments, config.substitutions, "your-package", "42.0"
+        ),
+        file=out,
+    )
 
 
 def _fail(msg: str) -> NoReturn:

--- a/src/hatch_fancy_pypi_readme/hooks.py
+++ b/src/hatch_fancy_pypi_readme/hooks.py
@@ -27,6 +27,7 @@ class FancyReadmeMetadataHook(MetadataHookInterface):
             "text": build_text(
                 config.fragments,
                 config.substitutions,
+                package_name=metadata.get("name", ""),
                 version=metadata.get("version", ""),
             ),
         }

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -11,8 +11,15 @@ class TestBuildText:
         """
         A single text fragment becomes the readme.
         """
-        assert "This is the README for 1.0!" == build_text(
-            [TextFragment("This is the README for $HFPR_VERSION!")], [], "1.0"
+        assert "This is the README for your-package 1.0!" == build_text(
+            [
+                TextFragment(
+                    "This is the README for $HFPR_PACKAGE_NAME $HFPR_VERSION!"
+                )
+            ],
+            [],
+            "your-package",
+            "1.0",
         )
 
     def test_multiple_text_fragment(self):
@@ -26,5 +33,6 @@ class TestBuildText:
                 TextFragment("This is the README!"),
             ],
             [],
+            "your-package",
             "1.0",
         )


### PR DESCRIPTION
Resolves https://github.com/hynek/hatch-fancy-pypi-readme/issues/63

This PR adds support for `$HFPR_PACKAGE_NAME` to be replaced with the package's name in readme substitutions, similar to https://github.com/hynek/hatch-fancy-pypi-readme/pull/39.

This is valuable for monorepos, where for example you may wish to replace relative links with absolute links for a number of different packages depending on which is being built.

